### PR TITLE
Fixes hardcoded Algolia index for price asc/desc

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -30,8 +30,8 @@ export const Search: React.FC<SearchParams> = () => {
           defaultRefinement={config.algoliaIndexName}
           items={[
             { value: config.algoliaIndexName, label: t('featured') },
-            { value: 'product_price_asc', label: t('price-asc') },
-            { value: 'product_price_desc', label: t('price-desc') }
+            { value: `${config.algoliaIndexName}_price_asc`, label: t('price-asc') },
+            { value: `${config.algoliaIndexName}_price_desc`, label: t('price-desc') }
           ]}
         />
       </div>


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
Changes the index name for price ascending/descending Algolia replicas to begin with`Config.AlgoliaIndexName` instead of the hardcoded value `product`.  

Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests
- [x] Manual tests
    - Verified price_asc/desc work for Algolia replicas using the `Config.AlgoliaIndexName`
- [ ] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
