### PR TITLE
MT-5330 password auth when oidc exists

### DIFF
--- a/src/LoginDialog/LoginDialog.tsx
+++ b/src/LoginDialog/LoginDialog.tsx
@@ -25,6 +25,11 @@ export const LoginDialog: React.FC<AppModalLoginMainProps> = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [failedLogin, setFailedLogin] = useState(false);
 
+  const passwordAuthAvailable: boolean =
+    authenticationSettings?.data.allow_password_authentication !== undefined
+      ? authenticationSettings?.data.allow_password_authentication
+      : true;
+
   const handleClose = () => {
     setFailedLogin(false);
     handleModalClose();
@@ -48,24 +53,24 @@ export const LoginDialog: React.FC<AppModalLoginMainProps> = (props) => {
           <div className="logindialog__feedback">
           {failedLogin ? t('invalid-email-or-password') : ('')}
           </div>
-
-          {
-            authenticationSettings ?
-            authenticationSettings?.data.allow_password_authentication &&
-            <PasswordLoginForm handleModalClose={handleModalClose} isLoading={isLoading} setIsLoading={setIsLoading} setFailedLogin={setFailedLogin} />
-            :
-            <div className="epminiLoader" />
-          }
+          {passwordAuthAvailable && (
+            <PasswordLoginForm
+              handleModalClose={handleModalClose}
+              isLoading={isLoading}
+              setIsLoading={setIsLoading}
+              setFailedLogin={setFailedLogin}
+            />
+          )}
 
           {
             oidcProfiles ?
             [
-              authenticationSettings?.data.allow_password_authentication && <LoginDialogDivider/>,
+              passwordAuthAvailable && <LoginDialogDivider key="oidcLoginButtonDivider" />,
               <OidcLoginButtons key="OidcLoginButton"/>
             ]: (
               authenticationSettings &&
               [
-                authenticationSettings?.data.allow_password_authentication && <LoginDialogDivider/>,
+                passwordAuthAvailable && <LoginDialogDivider key="oidcLoginButtonLoaderDivider" />,
                 <div key="oidcLoginButtonLoader" className="epminiLoader" />
               ])
           }


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->
Fix for the issue: https://elasticpath.atlassian.net/browse/MT-5330


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests
- [x] Manual tests
- [x] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
