### PR TITLE
Fixed multiple calls to /token api

### DIFF
--- a/src/LoginDialog/OidcHandler.tsx
+++ b/src/LoginDialog/OidcHandler.tsx
@@ -6,40 +6,41 @@ import { generateRedirectUri } from './OidcUtilities'
 
 export const OidcHandler: React.FC<any> = ()=> {
 
-    const history = useHistory()
-    const location = useLocation()
-    const { setCustomerData } = useCustomerData();
+  const history = useHistory();
+  const historyPush = history.push;
+  const location = useLocation();
+  const locationSearch = location.search;
+  const { setCustomerData } = useCustomerData();
 
-    useEffect(() => {
-        async function setCustomerDataFromOidcCallback() {
-            const redirectInitialLocation:string = localStorage.getItem('location') || '/';
+  useEffect(() => {
+    async function setCustomerDataFromOidcCallback() {
+      const redirectInitialLocation: string = localStorage.getItem('location') || '/';
 
-            let query = new URLSearchParams(location.search);
-            const code = query.get('code')
-            const state = query.get('state')
-            const codeVerifier = localStorage.getItem('code_verifier');
+      let query = new URLSearchParams(locationSearch);
+      const code = query.get('code')
+      const state = query.get('state')
+      const codeVerifier = localStorage.getItem('code_verifier');
 
-            if(code !== undefined && state !== undefined) {
-                if (state === localStorage.getItem('state') && typeof codeVerifier === "string" ) {
+      if (code !== undefined && state !== undefined) {
+        if (state === localStorage.getItem('state') && typeof codeVerifier === "string" ) {
 
-                    const response: any = await oidcLogin(code!, generateRedirectUri(), codeVerifier)
-                    const result = response;
-                    
-                    setCustomerData(result.token, result.customer_id);
-                    
-                    history.push(redirectInitialLocation);
-                } else {
-                    alert('Unable to validate identity');
-                    history.push(redirectInitialLocation);
-                }
+          const response: any = await oidcLogin(code!, generateRedirectUri(), codeVerifier)
+          const result = response;
+          setCustomerData(result.token, result.customer_id);
 
-                localStorage.removeItem('location')
-                localStorage.removeItem('state')
-            }
+          historyPush(redirectInitialLocation);
+        } else {
+          alert('Unable to validate identity');
+          historyPush(redirectInitialLocation);
         }
 
-        setCustomerDataFromOidcCallback();
-    });
+        localStorage.removeItem('location')
+        localStorage.removeItem('state')
+      }
+    }
 
-    return( <div className="epminiLoader --center" />   )
+    setCustomerDataFromOidcCallback();
+  }, [historyPush, locationSearch, setCustomerData]);
+
+  return( <div className="epminiLoader --center" />   )
 }

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import constate from 'constate';
 import * as moltin from '@moltin/sdk';
 import { getCustomer, getAddresses, getAllOrders, loadCategoryTree, getCartItems, loadCustomerAuthenticationSettings, loadOidcProfiles } from './service';
@@ -127,13 +127,13 @@ function useCustomerDataState() {
     }
   }, [customerId, customerToken]);
 
-  const setCustomerData = (token: string, id: string) => {
+  const setCustomerData = useCallback((token: string, id: string) => {
     localStorage.setItem('mtoken', token);
     localStorage.setItem('mcart', id);
     localStorage.setItem('mcustomer', id);
     setCustomerToken(token);
     setCustomerId(id);
-  };
+  }, []);
 
   const clearCustomerData = () => {
     localStorage.setItem('mtoken', '');


### PR DESCRIPTION
Description:
<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets? -->

Added dependencies in `useEffect()` method of OidcHandler which stopped it from reloading on every re-render. This was causing multiple calls to `/token` api after successful oidc login.

https://elasticpath.atlassian.net/browse/MT-5415
  
Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests
- [x] Manual tests
- [ ] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
