### PR TITLE
Fixed issue with login dialog separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "dependencies": {
-    "@moltin/sdk": "5.0.0-beta.1",
+    "@moltin/sdk": "^5.0.0-beta.2",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",

--- a/src/LoginDialog/LoginDialog.tsx
+++ b/src/LoginDialog/LoginDialog.tsx
@@ -18,7 +18,7 @@ interface AppModalLoginMainProps {
 export const LoginDialog: React.FC<AppModalLoginMainProps> = (props) => {
   const { handleModalClose, openModal } = props;
 
-  const { authenticationSettings, oidcProfiles }: any = useCustomerAuthenticationSettings()
+  const { authenticationSettings, oidcProfiles } = useCustomerAuthenticationSettings()
 
   const { t } = useTranslation();
 
@@ -51,8 +51,9 @@ export const LoginDialog: React.FC<AppModalLoginMainProps> = (props) => {
         </div>
         <div className="logindialog__body">
           <div className="logindialog__feedback">
-          {failedLogin ? t('invalid-email-or-password') : ('')}
+            {failedLogin ? t('invalid-email-or-password') : ('')}
           </div>
+
           {passwordAuthAvailable && (
             <PasswordLoginForm
               handleModalClose={handleModalClose}
@@ -62,18 +63,11 @@ export const LoginDialog: React.FC<AppModalLoginMainProps> = (props) => {
             />
           )}
 
-          {
-            oidcProfiles ?
-            [
-              passwordAuthAvailable && <LoginDialogDivider key="oidcLoginButtonDivider" />,
-              <OidcLoginButtons key="OidcLoginButton"/>
-            ]: (
-              authenticationSettings &&
-              [
-                passwordAuthAvailable && <LoginDialogDivider key="oidcLoginButtonLoaderDivider" />,
-                <div key="oidcLoginButtonLoader" className="epminiLoader" />
-              ])
-          }
+          {passwordAuthAvailable && oidcProfiles && oidcProfiles.data.length > 0 && (
+            <LoginDialogDivider />
+          )}
+
+          <OidcLoginButtons />
         </div>
       </div>
     </Modal>

--- a/src/LoginDialog/OidcLoginButtons.tsx
+++ b/src/LoginDialog/OidcLoginButtons.tsx
@@ -12,32 +12,36 @@ import { generateOidcLoginRedirectUrl } from './OidcUtilities';
 import './OidcLoginButtons.scss';
 
 export const OidcLoginButtons: React.FC = () => {
-    const { authenticationSettings, oidcProfiles }: any = useCustomerAuthenticationSettings()
-    const [ isLoading ] = useState(false);
-    const location = useLocation()
+  const { authenticationSettings, isLoadingOidcProfiles, oidcProfiles } = useCustomerAuthenticationSettings()
+  const [ isLoading ] = useState(false);
+  const location = useLocation()
 
-    const handleOidcButtonClicked = async (profile:any, cId:any) => {
-        const authenticationRealmId = authenticationSettings.data.relationships['authentication-realm'].data.id
+  const handleOidcButtonClicked = async (profile:any, cId:any) => {
+    const authenticationRealmId = authenticationSettings.data.relationships['authentication-realm'].data.id;
 
-        const { links } = await getOidcProfile(authenticationRealmId, profile.id)
-        const baseRedirectUrl = links['authorization-endpoint']
+    const { links } = await getOidcProfile(authenticationRealmId, profile.id);
+    const baseRedirectUrl = links['authorization-endpoint'];
 
-        window.location.href = await generateOidcLoginRedirectUrl(baseRedirectUrl, cId, location.pathname);
-    }
-    const clientId = `${authenticationSettings?.data.meta.client_id}`
+    window.location.href = await generateOidcLoginRedirectUrl(baseRedirectUrl, cId, location.pathname);
+  }
 
-    return (
-        <div className="auth-opt">
-        {
-            oidcProfiles.data.map((profile:any)=>{
+  const clientId = `${authenticationSettings?.data.meta.client_id}`;
 
-                return (
-                    <button key={`${profile.name}`} className={`authbtn ${profile.name}`} onClick={()=>handleOidcButtonClicked(profile, clientId)}>
-                        {isLoading ? 'Loading' : `Login with ${profile.name}`}
-                    </button>
-                );
-            })
-        }
-        </div>
-        );
+  return (
+    <div className="auth-opt">
+      {isLoadingOidcProfiles && (
+        <div key="oidcLoginButtonLoader" className="epminiLoader" />
+      )}
+
+      {oidcProfiles && (
+        oidcProfiles.data.map((profile:any)=>{
+          return (
+            <button key={`${profile.name}`} className={`authbtn ${profile.name}`} onClick={()=>handleOidcButtonClicked(profile, clientId)}>
+              {isLoading ? 'Loading' : `Login with ${profile.name}`}
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
 };

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -359,24 +359,26 @@ function useCompareProductsState() {
 }
 
 function useCustomerAuthenticationSettingsState() {
-  const [ authenticationSettings, setAuthenticationSettings ] = useState<object>()
-  const [ oidcProfiles, setOidcProfiles ] = useState<object>();
+  const [authenticationSettings, setAuthenticationSettings] = useState<any>()
+  const [isLoadingOidcProfiles, setIsLoadingOidcProfiles] = useState(true);
+  const [oidcProfiles, setOidcProfiles] = useState<moltin.ResourcePage<moltin.Profile>>();
 
   useEffect(()=>{
     loadCustomerAuthenticationSettings().then((authSettings) => {
       setAuthenticationSettings(authSettings);
 
-      const authenticationRealmId = authSettings?.data?.relationships['authentication-realm']?.data?.id
+      const authenticationRealmId = authSettings?.data?.relationships['authentication-realm']?.data?.id;
 
       loadOidcProfiles(authenticationRealmId).then((profiles) => {
         setOidcProfiles(profiles);
+        setIsLoadingOidcProfiles(false);
       })
     }).catch((err)=>{
       console.log(err)
     });
-  },[])
+  }, [])
 
-  return { authenticationSettings, oidcProfiles }
+  return { authenticationSettings, isLoadingOidcProfiles, oidcProfiles };
 }
 
 function useCartItemsState() {

--- a/src/service.ts
+++ b/src/service.ts
@@ -11,12 +11,12 @@ export async function loadCustomerAuthenticationSettings(): Promise<any> {
   return moltin.AuthenticationSettings.Get()
 }
 
-export async function loadOidcProfiles(realmId: string): Promise<any> {
+export async function loadOidcProfiles(realmId: string): Promise<moltin.ResourcePage<moltin.Profile>> {
   const moltin = MoltinGateway({
     client_id: config.clientId,
     host: config.endpointURL,
   });
-  return moltin.OidcProfile.All(realmId)
+  return moltin.OidcProfile.All(realmId);
 }
 
 export function getOidcProfile(realmId: string, profileId: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,10 +1450,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@moltin/sdk@5.0.0-beta.1":
-  version "5.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@moltin/sdk/-/sdk-5.0.0-beta.1.tgz#ecf062cafdafda9ffbe43f19a4d5fcfef787c474"
-  integrity sha512-uJjlgR3Np0sBUyXwiiho5M7LC1EbgQHT6utmHftuepCuzUat+cQHu9nSKGTD6+5C9DNQXKzKumCPXejNfIYaWg==
+"@moltin/sdk@^5.0.0-beta.2":
+  version "5.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@moltin/sdk/-/sdk-5.0.0-beta.2.tgz#88060a11b9df5d38143c8ec7ac039ea6c2dc3945"
+  integrity sha512-C+dwGBRb/3k8nNZqFCWJgg+naH+LbarFsYcDbt0ZPJmcWSWvCZCPxwcJxRnl5Ddq1WB3Bj3uiz1ZDvgxESSIdA==
   dependencies:
     es6-promise "^4.0.5"
     fetch-everywhere "^1.0.5"


### PR DESCRIPTION
Description:

Login dialog `---OR---` separator should be shown only when there is user/pass login **and** at least one oidc provider. Otherwise there shouldn't be a separator 


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [ ] E2E tests
- [x] Manual tests
- [ ] Accessibility tests (no new react-axe errors in console)

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [ ] Requires documentation updates
- [ ] Requires Storybook component updates
