### PR TITLE
[MT-4688] get base64 url encoded of state token

### DIFF
--- a/src/LoginDialog/OidcUtilities.ts
+++ b/src/LoginDialog/OidcUtilities.ts
@@ -3,7 +3,12 @@ import {generateCodeVerifierAndS256Challenge, PkceParameters} from './PkceUtilit
 const generateStateToken = () => {
     var array = new Uint8Array(20);
     const randomValues = window.crypto.getRandomValues(array)
-    return randomValues.join('');
+    return getBase64URLEncodedOfString(randomValues.join(''));
+}
+
+const getBase64URLEncodedOfString = (str: string) => {
+    return btoa(str)
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 export const generateRedirectUri = () => {


### PR DESCRIPTION
Description:
the random state parameter for OIDC needs to be base64 . a new function is added to generate base64 url encoded of state
Linting:
<!--Have you validated that no linting errors are introduced? -->
- [ ] No linting errors

Tests:
- [ ] Manual tests

